### PR TITLE
Feature: metric field name option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `coverage-check` will be documented in this file.
 
 ---
 
+## 1.1.0 - 2021-07-04
+
+- add `--metric/-m` option flag
+
 ## 1.0.0 - 2021-07-03
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -38,14 +38,22 @@ If you don't specify the `--require/-r` flag, only the percentage of code covera
 ./vendor/bin/coverage-check clover.xml
 ./vendor/bin/coverage-check clover.xml --require=50
 ./vendor/bin/coverage-check clover.xml -r 80.5
+./vendor/bin/coverage-check clover.xml -m statement -r 75
 ```
 
 ## Available Options
 
 | Option | Description |
 | --- | --- |
-| `--require` or `-r` | Enforce a minimum code coverage value |
 | `--coverage-only` or `-C` | Only display the code coverage value |
+| `--metric` or `-m` `<name>` | Use the specified metric field for calculating coverage. Valid values are `element` _(default)_, `method`, or `statement` |
+| `--require` or `-r` `<value>` | Enforce a minimum code coverage value, where `<value>` is an integer or decimal value |
+
+## Metric fields
+
+The field that is used to calculate code coverage can be specified using the `--metric=<name>` or `-m <name>` option.
+
+Valid field names are `element` _(the default)_, `statement`, and `method`.
 
 ## Generating clover-format coverage files
 

--- a/src/Commands/CheckCoverageCommand.php
+++ b/src/Commands/CheckCoverageCommand.php
@@ -27,6 +27,7 @@ class CheckCoverageCommand extends Command
     {
         $this->addArgument('filename')
             ->addOption('require', 'r', InputOption::VALUE_REQUIRED, 'Require a minimum code coverage percentage', null)
+            ->addOption('metric', 'm', InputOption::VALUE_REQUIRED, 'Use a specific metric field (element, statement, or method)')
             ->addOption('coverage-only', 'C', InputOption::VALUE_NONE, 'Display only the code coverage percentage')
             ->setDescription('Checks a clover-format coverage file for a minimum coverage percentage and optionally enforces it.');
     }
@@ -52,7 +53,7 @@ class CheckCoverageCommand extends Command
             return $result ? Command::SUCCESS : Command::FAILURE;
         }
 
-        $checker = new CoverageChecker($this->config->filename);
+        $checker = new CoverageChecker($this->config->filename, $this->config);
         $coverage = $checker->getCoveragePercent();
 
         $this->displayCoverageResults($coverage);
@@ -62,7 +63,7 @@ class CheckCoverageCommand extends Command
 
     protected function checkCoverage(string $filename, float $requiredPercentage): array
     {
-        $checker = new CoverageChecker($filename);
+        $checker = new CoverageChecker($filename, $this->config);
 
         return [$checker->check($requiredPercentage), $checker->getCoveragePercent()];
     }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -16,9 +16,10 @@ class Configuration
     /** @var bool */
     public $displayCoverageOnly = false;
 
-    public $metricField = 'elements';
+    /** @var string */
+    public $metricField;
 
-    public function __construct(string $filename, bool $requireMode, $required, bool $displayCoverageOnly, string $metricField = 'element')
+    public function __construct(string $filename, bool $requireMode, $required, bool $displayCoverageOnly, string $metricField)
     {
         $this->filename = $filename;
         $this->required = $required;

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -16,18 +16,25 @@ class Configuration
     /** @var bool */
     public $displayCoverageOnly = false;
 
-    public function __construct(string $filename, bool $requireMode, $required, bool $displayCoverageOnly)
+    public $metricField = 'elements';
+
+    public function __construct(string $filename, bool $requireMode, $required, bool $displayCoverageOnly, string $metricField = 'element')
     {
         $this->filename = $filename;
         $this->required = $required;
         $this->requireMode = $requireMode;
         $this->displayCoverageOnly = $displayCoverageOnly;
+        $this->metricField = rtrim(strtolower($metricField), 's');
     }
 
     public function validate(): void
     {
         if (! file_exists($this->filename) || ! is_file($this->filename)) {
             throw new \InvalidArgumentException('Invalid input file provided.');
+        }
+
+        if (! in_array($this->metricField, ['element', 'statement', 'method'])) {
+            throw new \InvalidArgumentException('Invalid metric field name provided. Valid options are "element", "statement", "method".');
         }
     }
 }

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -12,7 +12,12 @@ class ConfigurationFactory
         $requireMode = $input->hasOption('require') && $input->getOption('require') !== null;
         $percentage = $requireMode ? (float)$input->getOption('require') : null;
         $displayCoverageOnly = $input->hasOption('coverage-only') && $input->getOption('coverage-only') === true;
+        $metricField = 'element';
 
-        return new Configuration($filename, $requireMode, $percentage, $displayCoverageOnly);
+        if ($input->hasOption('metric') && $input->getOption('metric') !== null) {
+            $metricField = $input->getOption('metric');
+        }
+
+        return new Configuration($filename, $requireMode, $percentage, $displayCoverageOnly, $metricField);
     }
 }

--- a/tests/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Configuration/ConfigurationFactoryTest.php
@@ -16,6 +16,7 @@ class ConfigurationFactoryTest extends TestCase
         $inputDefinition = new InputDefinition([
             new InputArgument('filename', InputArgument::REQUIRED),
             new InputOption('require', 'r', InputOption::VALUE_REQUIRED),
+            new InputOption('metric', 'm', InputOption::VALUE_REQUIRED),
             new InputOption('coverage-only', 'C', InputOption::VALUE_NONE),
         ]);
 
@@ -66,5 +67,18 @@ class ConfigurationFactoryTest extends TestCase
         }
 
         $this->assertFalse($hasException);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_validating_the_metric_field_with_an_invalid_value()
+    {
+        $filename = realpath(__DIR__.'/../data/coverage-clover.xml');
+
+        $input = $this->createInput(['filename' => $filename, '--metric' => 'bad']);
+        $config = ConfigurationFactory::create($input);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $config->validate();
     }
 }

--- a/tests/CoverageCheckerTest.php
+++ b/tests/CoverageCheckerTest.php
@@ -11,7 +11,7 @@ class CoverageCheckerTest extends TestCase
     /** @test */
     public function it_gets_the_coverage_percentage()
     {
-        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, 'element');
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'element');
         $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
 
         $this->assertEquals(89.8765, round($checker->getCoveragePercent(), 4));
@@ -20,10 +20,28 @@ class CoverageCheckerTest extends TestCase
     /** @test */
     public function it_checks_for_a_minimum_coverage_percentage()
     {
-        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, 'element');
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'element');
         $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
 
         $this->assertTrue($checker->check(75));
         $this->assertFalse($checker->check(99));
+    }
+
+    /** @test */
+    public function it_gets_the_coverage_percentage_for_the_statement_metric()
+    {
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'statement');
+        $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
+
+        $this->assertEquals(90.6279, round($checker->getCoveragePercent(), 4));
+    }
+
+    /** @test */
+    public function it_gets_the_coverage_percentage_for_the_method_metric()
+    {
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'method');
+        $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
+
+        $this->assertEquals(87.4439, $checker->getCoveragePercent());
     }
 }

--- a/tests/CoverageCheckerTest.php
+++ b/tests/CoverageCheckerTest.php
@@ -2,6 +2,7 @@
 
 namespace Permafrost\CoverageCheck\Tests;
 
+use Permafrost\CoverageCheck\Configuration\Configuration;
 use Permafrost\CoverageCheck\CoverageChecker;
 use PHPUnit\Framework\TestCase;
 
@@ -10,7 +11,8 @@ class CoverageCheckerTest extends TestCase
     /** @test */
     public function it_gets_the_coverage_percentage()
     {
-        $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml');
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, 'element');
+        $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
 
         $this->assertEquals(89.8765, round($checker->getCoveragePercent(), 4));
     }
@@ -18,7 +20,8 @@ class CoverageCheckerTest extends TestCase
     /** @test */
     public function it_checks_for_a_minimum_coverage_percentage()
     {
-        $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml');
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, 'element');
+        $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
 
         $this->assertTrue($checker->check(75));
         $this->assertFalse($checker->check(99));


### PR DESCRIPTION
This PR adds the `--metric/-m` option to allow the user to specify the metric field name used when calculating the code coverage percentage.