### PR TITLE
Add precision option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you don't specify the `--require/-r` flag, only the percentage of code covera
 ./vendor/bin/coverage-check clover.xml --require=50
 ./vendor/bin/coverage-check clover.xml -r 80.5
 ./vendor/bin/coverage-check clover.xml -m statement -r 75
+./vendor/bin/coverage-check clover.xml --precision=1
 ```
 
 ## Available Options
@@ -47,6 +48,7 @@ If you don't specify the `--require/-r` flag, only the percentage of code covera
 | --- | --- |
 | `--coverage-only` or `-C` | Only display the code coverage value |
 | `--metric` or `-m` `<name>` | Use the specified metric field for calculating coverage. Valid values are `element` _(default)_, `method`, or `statement` |
+| `--precision` or `-p` `<value>` | Use the specified precision when calculating the code coverage percentage, where `<value>` is an integer _(default: 4)_ |
 | `--require` or `-r` `<value>` | Enforce a minimum code coverage value, where `<value>` is an integer or decimal value |
 
 ## Metric fields
@@ -104,7 +106,7 @@ jobs:
         run: ./vendor/bin/phpunit --coverage-clover clover.xml
 
       - name: Enforce 75% code coverage
-        run: ./vendor/bin/coverage-check clover.xml --require=75
+        run: ./vendor/bin/coverage-check clover.xml --require=75 --precision=2
 ```
 
 ## Testing

--- a/src/Commands/CheckCoverageCommand.php
+++ b/src/Commands/CheckCoverageCommand.php
@@ -29,6 +29,7 @@ class CheckCoverageCommand extends Command
             ->addOption('require', 'r', InputOption::VALUE_REQUIRED, 'Require a minimum code coverage percentage', null)
             ->addOption('metric', 'm', InputOption::VALUE_REQUIRED, 'Use a specific metric field (element, statement, or method)')
             ->addOption('coverage-only', 'C', InputOption::VALUE_NONE, 'Display only the code coverage percentage')
+            ->addOption('precision', 'p', InputOption::VALUE_REQUIRED, 'Precision to use when rounding the code coverage percentage', 4)
             ->setDescription('Checks a clover-format coverage file for a minimum coverage percentage and optionally enforces it.');
     }
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -19,13 +19,17 @@ class Configuration
     /** @var string */
     public $metricField;
 
-    public function __construct(string $filename, bool $requireMode, $required, bool $displayCoverageOnly, string $metricField)
+    /** @var int */
+    public $precision;
+
+    public function __construct(string $filename, bool $requireMode, $required, bool $displayCoverageOnly, string $metricField, int $precision)
     {
         $this->filename = $filename;
         $this->required = $required;
         $this->requireMode = $requireMode;
         $this->displayCoverageOnly = $displayCoverageOnly;
         $this->metricField = rtrim(strtolower($metricField), 's');
+        $this->precision = $precision;
     }
 
     public function validate(): void

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -12,12 +12,13 @@ class ConfigurationFactory
         $requireMode = $input->hasOption('require') && $input->getOption('require') !== null;
         $percentage = $requireMode ? (float)$input->getOption('require') : null;
         $displayCoverageOnly = $input->hasOption('coverage-only') && $input->getOption('coverage-only') === true;
+        $precision = $input->hasOption('precision') ? (int)$input->getOption('precision') : 4;
         $metricField = 'element';
 
         if ($input->hasOption('metric') && $input->getOption('metric') !== null) {
             $metricField = $input->getOption('metric');
         }
 
-        return new Configuration($filename, $requireMode, $percentage, $displayCoverageOnly, $metricField);
+        return new Configuration($filename, $requireMode, $percentage, $displayCoverageOnly, $metricField, $precision);
     }
 }

--- a/src/CoverageChecker.php
+++ b/src/CoverageChecker.php
@@ -39,7 +39,7 @@ class CoverageChecker
         $totalElements = $this->getMetricFieldSum($metrics, $totalName);
         $checkedElements = $this->getMetricFieldSum($metrics, $coveredName);
 
-        return round(($checkedElements / $totalElements) * 100, 4);
+        return round(($checkedElements / $totalElements) * 100, $this->config->precision);
     }
 
     public function check(float $minPercentage): bool

--- a/tests/CoverageCheckerTest.php
+++ b/tests/CoverageCheckerTest.php
@@ -11,16 +11,33 @@ class CoverageCheckerTest extends TestCase
     /** @test */
     public function it_gets_the_coverage_percentage()
     {
-        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'element');
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'element', 4);
         $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
 
         $this->assertEquals(89.8765, round($checker->getCoveragePercent(), 4));
     }
 
     /** @test */
+    public function it_gets_the_coverage_percentage_using_the_specified_precision()
+    {
+        $map = [
+            0 => 90.0,
+            1 => 89.9,
+            2 => 89.88,
+        ];
+
+        foreach($map as $precision => $value) {
+            $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'element', $precision);
+            $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
+
+            $this->assertEquals($value, $checker->getCoveragePercent());
+        }
+    }
+
+    /** @test */
     public function it_checks_for_a_minimum_coverage_percentage()
     {
-        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'element');
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'element', 4);
         $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
 
         $this->assertTrue($checker->check(75));
@@ -30,7 +47,7 @@ class CoverageCheckerTest extends TestCase
     /** @test */
     public function it_gets_the_coverage_percentage_for_the_statement_metric()
     {
-        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'statement');
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'statement', 4);
         $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
 
         $this->assertEquals(90.6279, round($checker->getCoveragePercent(), 4));
@@ -39,7 +56,7 @@ class CoverageCheckerTest extends TestCase
     /** @test */
     public function it_gets_the_coverage_percentage_for_the_method_metric()
     {
-        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'method');
+        $config = new Configuration(__DIR__ . '/data/coverage-clover.xml', false, false, false, 'method', 4);
         $checker = new CoverageChecker(__DIR__ . '/data/coverage-clover.xml', $config);
 
         $this->assertEquals(87.4439, $checker->getCoveragePercent());


### PR DESCRIPTION
This PR adds the `--precision` option to `CoverageCheckCommand`, allowing the precision used when calculating the code coverage percentage to be specified.  Defaults to a value of `4`.